### PR TITLE
Work to connect network streams to channels, thread pools

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 mod tcp;
 mod threadpool;
 
+#[allow(dead_code)]
 fn run_threadpool() {
     let start = Instant::now();
 
@@ -50,7 +51,7 @@ fn run_network() {
 }
 
 fn main() {
-    run_threadpool();
+    // run_threadpool();
 
     run_network();
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,8 +1,11 @@
+use crossbeam_channel::{unbounded, Receiver};
 use rand::{self, Rng};
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
+
+use crate::threadpool::ThreadPool;
 
 const PORT: u16 = 12321;
 
@@ -29,22 +32,46 @@ impl Server {
     fn handle_client(&self, mut stream: TcpStream) {
         println!("    (Server) Handling client");
 
-        loop {
-            let buf = &mut [0; 8];
-            let bytes_read = stream.read(buf).unwrap();
-            if bytes_read == 0 {
-                println!("    (Server) Connection closed");
-                break;
+        let (response_tx, response_rx) = unbounded::<Receiver<u64>>();
+
+        // one thread to read network, sending to thread pool
+        let pool = ThreadPool::new(4);
+        let mut read_stream = stream.try_clone().unwrap();
+        thread::spawn(move || {
+            loop {
+                // read and parse data
+                let buf = &mut [0; 8];
+                let bytes_read = read_stream.read(buf).unwrap();
+                if bytes_read == 0 {
+                    println!("    (Server) Connection closed");
+                    break;
+                }
+                let val = u64::from_be_bytes(*buf);
+                println!("    (Server) Received: {}", val);
+
+                // send work to threadpool
+                let res = pool.execute(move || {
+                    let delay = rand::thread_rng().gen_range(10..=2000);
+                    thread::sleep(Duration::from_millis(delay));
+                    println!("    (Server) Computed {}", val * val);
+                    val * val
+                });
+
+                // send response channel to response thread
+                response_tx.send(res).unwrap();
             }
-            let val = u64::from_be_bytes(*buf);
-            // TODO: send work to threadpool
-            println!("    (Server) Received: {}", val);
-            let delay = rand::thread_rng().gen_range(10..=2000);
-            thread::sleep(Duration::from_millis(delay));
-            let out = val * val;
+
+            // once we finish all this, we shutdown the thread pool (end of queue, so after all work is done)
+            pool.shutdown();
+        });
+
+        // other thread reading thread pool responses, sending to network
+        for result in response_rx {
+            let out = result.recv().unwrap();
             let msg = out.to_be_bytes();
             stream.write(&msg).unwrap();
         }
+        println!("    (Server) Finished sending responses");
     }
 }
 
@@ -62,9 +89,16 @@ impl Client {
     // Send all info then wait for response
     pub fn work(&mut self) {
         println!("(Client) Sending work");
-        (0..20u64).for_each(|i| {
-            let msg = i.to_be_bytes();
-            self.stream.write(&msg).unwrap();
+
+        // do writing in another thread, one packet every 200 ms (total 4s send)
+        let mut client_stream = self.stream.try_clone().unwrap();
+        let writer = thread::spawn(move || {
+            (0..20u64).for_each(|i| {
+                let msg = i.to_be_bytes();
+                client_stream.write(&msg).unwrap();
+                println!("(Client) sent {}", i);
+                thread::sleep(Duration::from_millis(200));
+            });
         });
 
         println!("(Client) Waiting for response");
@@ -85,6 +119,7 @@ impl Client {
             }
         }
 
+        writer.join().unwrap();
         self.stream.shutdown(std::net::Shutdown::Both).unwrap();
     }
 }


### PR DESCRIPTION
I built the two components (local threadpool for tasks, and sending work over TcpStream) on main.

This works on an approach to connect the TcpStream to the threadpool and channels.

I ended up cloning each stream and handling it with two threads. One to write to the TcpStream (possibly reading from a channel) and the other to read from the TcpStream (possibly writing input to channel / threadpool). It works and runs nicely in parallel, but I am not sure if it is the best or most idiomatic approach.

(Please ignore `.unwrap()` everywhere and no error handling, this is demo code)